### PR TITLE
added LASTUSER to workflow-attribute and changed custom email templates handling

### DIFF
--- a/data/System/VarWORKFLOW.txt
+++ b/data/System/VarWORKFLOW.txt
@@ -10,6 +10,7 @@
 | =%<nop>WORKFLOWHISTORY%= | Expands to the history of state transitions the topic has undergone. The format of the history is dictated by the =WORKFLOWHISTORYFORMAT= (described below). |
 | =%<nop>WORKFLOWLASTREV{"State"}%= | Expands to the version number when the document was last in the state _State_. |
 | =%<nop>WORKFLOWLASTTIME{"State"}%= | Expands to the timestamp when the document was last in the _State_ state. For example, =%<nop>WORKFLOWLASTTIME{"APPROVED"}%= would be replaced by the timestamp when the document was last in the =APPROVED= state. |
+| =%<nop>WORKFLOWLASTUSER{"State"}%= | Expands to the last user who transitioned the document into the state _State_. |
 | =%<nop>WORKFLOWLASTVERSION{"State"}%= | Expands to a link to the version of the document when it was last in the state _State_. |
 | =%<nop>WORKFLOWSTATE%= | Expands to the current state of the document. It can also be given a =topic= parameter (default), in which case the state of that topic is returned. |
 | =%<nop>WORKFLOWSTATEMESSAGE%= | Expands to the corresponding message in the state table. |

--- a/data/System/WorkflowPlugin.txt
+++ b/data/System/WorkflowPlugin.txt
@@ -154,6 +154,8 @@ viewed topic:
 | WAITINGFORAPPROVAL | approve  | %META{"formfield" name="ApprovedState"}% | %META{"formfield" name="MayApprove"}% |
 </verbatim>
 
+If you want to exclude the user who changed a specific state last, even though the user is generally allowed to, you can add =not(LASTUSER_{State})= to the =Allowed= column of the transition table and the last user for the specified state will be excluded.
+
 You can also define other macros starting with =WORKFLOW= in the workflow
 description topic. These will be expanded to their defined values in any
 topic that uses the workflow. For example:

--- a/data/System/WorkflowPlugin.txt
+++ b/data/System/WorkflowPlugin.txt
@@ -95,6 +95,7 @@ If a *Notify* column is given, that column can contain a comma-separated list of
 | Email addresses | webmaster@example.com | |
 | User wiki names | Main.WikiGuest | |
 | Wiki group names | Main.AdminGroup | |
+| Workflow Attribute names | LASTUSER_APPROVED | LASTUSER_{State} |
 | Email templates | =template(!Web.MyTopic)= | Must be wrapped in parentheses and proceeded by the word =template=, all lowercase, no spaces. |
 
 When a transition is fired, any email addresses provided in the *Notify* column (or resolved from wiki/group names) will be notified, with a message formatted according to the default email template provided with the plugin.  You can override this template by setting the =WORKFLOWDEFAULTEMAILTEMPLATE= preference in your workflow description topic.  Set that to a topic that contains a valid email notification template (see example below), and all email addresses provided will receive messages formatted according to that template:
@@ -113,7 +114,7 @@ Content-Type: text/plain
 
 Email notification templates should be topics formatted like the example above, with the headers each on their own line, followed by a single colon, then their values, with the message body begining below the " =Content-Type: text/plain= " line.  Also note the =%EMAILTO%= macro on the =To:= line; any email addresses pulled from the *Notify* column for a given transition will be expanded here.  If you override the default email template using the =WORKFLOWDEFAULTEMAILTEMPLATE= preference, it *must* use the =%EMAILTO%= to pull in recipients, otherwise you'll need to provide your own macros, and any email addresses provided in the *Notify* column _will be ignored_.  See the [[%%BASETOPIC%#Content_45sensitive_workflows][content-sensitive workflows]] section for more on how WorkflowPlugin expands macros.
 
-For more sophisticated email notification, you can also write one or more custom email templates for each transition.  Email notification templates are *completely independent* of both the default email template and other email adresses or usernames provided in the *Notify* column for their transition.  Custom notification templates must provide valid headers that define their recipients, and they do not have access to the =EMAILTO= macro, so other email addresses provided will *not* be sent through custom templates (but they can still go out through the default email template).
+For more sophisticated email notification, you can also write one or more custom email templates for each transition. Custom notification templates can either provide valid headers that define their recipients or access the =EMAILTO= macro, so other email addresses provided will be sent exclusively through custom templates.
 
 For example, the *Notify* column in the transition below will email =jim@example.com= using the default template, and execute both the =EmailOne= and =EmailTwo= templates, sending the results to whatever email addresses are defined on their respective =To=, =Cc=, or =Bcc= lines:
 <verbatim>

--- a/lib/Foswiki/Plugins/WorkflowPlugin.pm
+++ b/lib/Foswiki/Plugins/WorkflowPlugin.pm
@@ -63,6 +63,8 @@ sub initPlugin {
         \&_WORKFLOWLASTTIME );
     Foswiki::Func::registerTagHandler( 'WORKFLOWLASTVERSION',
         \&_WORKFLOWLASTVERSION );
+    Foswiki::Func::registerTagHandler( 'WORKFLOWLASTUSER',
+        \&_WORKFLOWLASTUSER );
 
     return 1;
 }
@@ -526,6 +528,22 @@ sub _WORKFLOWLASTVERSION {
     return $val
       ? CGI::a( { href => "$url?rev=$val" }, "revision $val" )
       : '';
+}
+
+sub _WORKFLOWLASTUSER {
+    my ( $session, $attr, $topic, $web ) = @_;
+
+    if ( defined $attr->{topic} ) {
+        ( $web, $topic ) =
+          Foswiki::Func::normalizeWebTopicName( $attr->{web} || $web,
+            $attr->{topic} );
+    }
+    my $state = $attr->{_DEFAULT};
+    return '<span class="foswikiAlert">No state given</span>' unless $state;
+    my ($rev) = defined $attr->{rev} ? ( $attr->{rev} =~ /(\d+)/ ) : ();
+    my $controlledTopic = _initTOPIC( $web, $topic, $rev );
+    return '' unless $controlledTopic;
+    return $controlledTopic->getState("LASTUSER_$state") || '';
 }
 
 sub _removedMacro {

--- a/lib/Foswiki/Plugins/WorkflowPlugin/ControlledTopic.pm
+++ b/lib/Foswiki/Plugins/WorkflowPlugin/ControlledTopic.pm
@@ -106,7 +106,7 @@ sub setState {
     return unless $this->isLatestRev();
     $this->{state}->{name} = $state;
     $this->{state}->{"LASTVERSION_$state"} = $version;
-    $this->{state}->{"LASTUSER_$state"} = Foswiki::Func::getCanonicalUserID();
+    $this->{state}->{"LASTUSER_$state"} = Foswiki::Func::getWikiUserName();
     $this->{state}->{"LASTTIME_$state"} =
       Foswiki::Func::formatTime( time(), undef, 'servertime' );
     $this->{meta}->put( "WORKFLOW", $this->{state} );

--- a/lib/Foswiki/Plugins/WorkflowPlugin/ControlledTopic.pm
+++ b/lib/Foswiki/Plugins/WorkflowPlugin/ControlledTopic.pm
@@ -106,6 +106,7 @@ sub setState {
     return unless $this->isLatestRev();
     $this->{state}->{name} = $state;
     $this->{state}->{"LASTVERSION_$state"} = $version;
+    $this->{state}->{"LASTUSER_$state"} = Foswiki::Func::getCanonicalUserID();
     $this->{state}->{"LASTTIME_$state"} =
       Foswiki::Func::formatTime( time(), undef, 'servertime' );
     $this->{meta}->put( "WORKFLOW", $this->{state} );

--- a/lib/Foswiki/Plugins/WorkflowPlugin/Workflow.pm
+++ b/lib/Foswiki/Plugins/WorkflowPlugin/Workflow.pm
@@ -129,7 +129,7 @@ sub getActions {
         my $nextState = $topic->expandMacros( $t->{nextstate} );
         next unless $nextState;
         my $allowed = $topic->expandMacros( $t->{allowed} );
-        next unless _isAllowed($allowed);
+        next unless _isAllowed($allowed, $topic);
         push( @actions, $t->{action} );
     }
     return @actions;
@@ -146,7 +146,7 @@ sub getNextState {
         my $nextState = $topic->expandMacros( $t->{nextstate} || '' );
         next unless $nextState;
         my $allowed = $topic->expandMacros( $t->{allowed} );
-        return $nextState if _isAllowed($allowed);
+        return $nextState if _isAllowed($allowed, $topic);
     }
     return undef;
 }
@@ -160,7 +160,7 @@ sub getNextForm {
     foreach my $t ( @{ $this->{transitions} } ) {
         next unless $t->{state} eq $currentState && $t->{action} eq $action;
         my $allowed = $topic->expandMacros( $t->{allowed} );
-        return $t->{form} if _isAllowed($allowed);
+        return $t->{form} if _isAllowed($allowed, $topic);
     }
     return undef;
 }
@@ -174,7 +174,7 @@ sub getNotifyList {
     foreach my $t ( @{ $this->{transitions} } ) {
         next unless $t->{state} eq $currentState && $t->{action} eq $action;
         my $allowed = $topic->expandMacros( $t->{allowed} );
-        return $t->{notify} if _isAllowed($allowed);
+        return $t->{notify} if _isAllowed($allowed, $topic);
     }
     return undef;
 }
@@ -202,7 +202,7 @@ sub allowEdit {
     return 0 unless $this->{states}->{$state};
     my $allowed =
       $topic->expandMacros( $this->{states}->{$state}->{allowedit} );
-    return _isAllowed($allowed);
+    return _isAllowed($allowed, $topic);
 }
 
 # finds out if the current user is allowed to do something.
@@ -210,7 +210,7 @@ sub allowEdit {
 # (comma,space)-separated list $allow, or they are a member
 # of a group in the list.
 sub _isAllowed {
-    my ($allow) = @_;
+    my ($allow, $topic) = @_;
 
     return 1 unless ($allow);
 
@@ -229,6 +229,19 @@ sub _isAllowed {
     }
 
     return 0 if ( defined($allow) && $allow =~ /^\s*nobody\s*$/ );
+    
+    #if a not(LASTUSER_{state}) is configured, translate this to a wikiname
+    #and authorize the current user
+    my $thisUser = Foswiki::Func::getWikiName();
+    foreach my $allowed ( split( /\s*,\s*/, $allow ) ) {
+        ( my $waste, $allowed ) = 
+            Foswiki::Func::normalizeWebTopicName( undef, $allowed );
+        if ( $allowed =~ /^not\((LASTUSER_.+)\)$/ ) {
+            my $notAllowed = $topic->getState( $1 );
+            $notAllowed =~ s/^.*\.//;    # strip web
+            return 0 if $thisUser eq $notAllowed;
+        }
+    }
 
     if ( ref( $Foswiki::Plugins::SESSION->{user} )
         && $Foswiki::Plugins::SESSION->{user}->can("isInList") )
@@ -236,7 +249,6 @@ sub _isAllowed {
         return $Foswiki::Plugins::SESSION->{user}->isInList($allow);
     }
     elsif ( defined &Foswiki::Func::isGroup ) {
-        my $thisUser = Foswiki::Func::getWikiName();
         foreach my $allowed ( split( /\s*,\s*/, $allow ) ) {
             ( my $waste, $allowed ) =
               Foswiki::Func::normalizeWebTopicName( undef, $allowed );


### PR DESCRIPTION
Hi!

The last user who changes the topic to another state will be stored in the workflow-attribute as `LASTUSER_{state}`, similar to the `LASTTIME_` and `LASTVERSION_` fields. To conveniently access the last user, the macro `%WORKFLOWLASTUSER{"state"}%` is introduced. The reason for this feature is to be able to send a notificiation to the user who last changed the topic to a specified state, e.g. if a topic is rejected the user who requested approval should be notified.

In our use-case it is not allowed for the user who requested approval to be the one who approves the final document even though this user may be generally allowed to. Thus this user can be excluded with the value `not(LASTUSER_{state}` in the `Allowed` column of the transition table. 

The last change concerns the handling of custom email templates. If one or many custom email templates are specified, the default email will not be sent. Every additional email-address in the column will be stored in the `EMAILTO`-macro thus making them available in the custom email templates. However if there are no additional email-addresses specified, the custom email templates must state the addresses themselves.

Please review these changes and consider merging them.

Cheers,
Markus
